### PR TITLE
feat: make API base URL configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ VUE_APP_NAME=Vue聊天应用
 VUE_APP_VERSION=1.0.0
 
 # API配置
+# API 基础地址，未设置时默认使用 http://localhost:8000/api
 VUE_APP_API_BASE_URL=http://localhost:8000/api
 VUE_APP_API_TIMEOUT=10000
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ VUE_APP_WEBSOCKET_HOST=localhost
 VUE_APP_WEBSOCKET_PORT=6001
 ```
 
+`VUE_APP_API_BASE_URL` 用于配置后端 API 地址，未设置时默认指向 `http://localhost:8000/api`。
+
 ## 部署
 
 执行 `npm run build` 后，会在 `dist/` 目录生成静态文件，可使用任意静态服务器（如 Nginx、Node `serve`）部署。确保后端 API 与 WebSocket 服务已正确配置并且环境变量一致。

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -5,9 +5,7 @@ import { Toast } from 'vant'
 
 // 创建axios实例
 const http = axios.create({
-  baseURL: process.env.NODE_ENV === 'production' 
-    ? 'https://api.yourapp.com' 
-    : 'http://localhost:8000/api',
+  baseURL: process.env.VUE_APP_API_BASE_URL || 'http://localhost:8000/api',
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,6 +82,7 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development'),
+        VUE_APP_API_BASE_URL: JSON.stringify(process.env.VUE_APP_API_BASE_URL || ''),
         VUE_APP_PUSHER_APP_KEY: JSON.stringify(process.env.VUE_APP_PUSHER_APP_KEY || ''),
         VUE_APP_PUSHER_APP_CLUSTER: JSON.stringify(process.env.VUE_APP_PUSHER_APP_CLUSTER || 'ap3'),
         VUE_APP_CLIENT_ID: JSON.stringify(process.env.VUE_APP_CLIENT_ID || '2'),


### PR DESCRIPTION
## Summary
- allow overriding axios base URL via `VUE_APP_API_BASE_URL`
- inject `VUE_APP_API_BASE_URL` into frontend through webpack `DefinePlugin`
- document API base URL configuration in `.env.example` and README

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b6f8ff5ba4832abf44e8eea4d46f5d