### PR TITLE
feat: expose api object and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
 import qs from 'qs'
-import router from '@/router'
+import router from '../router'
 import { Toast } from 'vant'
+import Vue from 'vue'
 
 // 创建axios实例
 const http = axios.create({
@@ -123,7 +124,7 @@ function checkCode(response) {
 }
 
 // 导出HTTP方法
-export default {
+const api = {
   // GET请求
   get(url, params = {}) {
     return http.get(url, { params }).then(checkCode)
@@ -154,6 +155,8 @@ export default {
   }
 }
 
-// 将http实例挂载到Vue原型上
-import Vue from 'vue'
-Vue.prototype.$api = http
+// 将封装后的API对象挂载到Vue原型上
+Vue.prototype.$api = api
+
+export { http, checkCode }
+export default api

--- a/tests/http.test.js
+++ b/tests/http.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs')
+const path = require('path')
+const assert = require('assert')
+const babel = require('@babel/core')
+const Module = require('module')
+
+// Transpile and load http.js
+const filePath = path.resolve(__dirname, '../src/utils/http.js')
+const source = fs.readFileSync(filePath, 'utf8')
+const { code } = babel.transformSync(source, {
+  presets: [['@babel/preset-env', { modules: 'commonjs' }]]
+})
+
+const m = new Module(filePath, module)
+m.filename = filePath
+m.paths = Module._nodeModulePaths(path.dirname(filePath))
+m.require = function (request) {
+  if (request === 'vant') {
+    return { Toast: { fail: () => {} } }
+  }
+  if (request === '../router') {
+    return { push: () => {} }
+  }
+  return Module.prototype.require.call(this, request)
+}
+m._compile(code, filePath)
+
+const { http, checkCode } = m.exports
+
+global.localStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {}
+}
+
+async function runTests() {
+  const ok = checkCode({ status: 200, data: { msg: 'ok' } })
+  assert.strictEqual(ok.status, 200)
+
+  const unauth = checkCode({ status: 401, data: { error: 'no' } })
+  assert.strictEqual(unauth.status, 401)
+
+  const handler = http.interceptors.response.handlers[0].rejected
+  const net = await handler({})
+  assert.strictEqual(net.status, -1)
+
+  console.log('http.js tests passed')
+}
+
+runTests()
+


### PR DESCRIPTION
## Summary
- export wrapped API object and attach it to `Vue.prototype.$api`
- add tests to verify `checkCode` and response interceptor behavior
- ignore `node_modules` from version control

## Testing
- `node tests/http.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6fda7b4e4832aaede0953d51405c0