### PR TITLE
chore: add eslint and prettier configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  env: {
+    browser: true,
+    node: true,
+    es2021: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:vue/recommended',
+  ],
+  parserOptions: {
+    ecmaVersion: 12,
+    sourceType: 'module',
+  },
+  rules: {},
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": false
+}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ npm run serve
 npm run build
 ```
 
+## 代码规范
+
+```bash
+# 代码检查
+npm run lint
+
+# 自动修复
+npm run lint:fix
+```
+
 ## 目录结构
 
 ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "serve": "webpack serve --config webpack.config.js --mode development",
-    "build": "webpack --config webpack.config.js --mode production"
+    "build": "webpack --config webpack.config.js --mode production",
+    "lint": "eslint \"src/**/*.{js,vue}\"",
+    "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
     "@babel/runtime": "^7.22.10",
@@ -34,6 +36,9 @@
     "vue-template-compiler": "^2.6.14",
     "webpack": "^5.88.2",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.15.0"
+    "webpack-dev-server": "^4.15.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-vue": "^9.15.1",
+    "prettier": "^3.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- add basic eslint config with vue plugin
- add prettier formatting rules
- expose lint and lint:fix scripts and document their usage

## Testing
- `npm install -D eslint eslint-plugin-vue prettier` (failed: 403 Forbidden)
- `npm run lint` (fails: ESLint couldn't find config with global ESLint)


------
https://chatgpt.com/codex/tasks/task_e_68b79709aa28832a93ff84237be83a73